### PR TITLE
Text revisions & download link update

### DIFF
--- a/details.md
+++ b/details.md
@@ -1,8 +1,8 @@
 # Open in Excel
 
-> **This extension requires Microsoft Excel and one of the following clients to be installed:**
-> - [Visual Studio 2017](https://www.visualstudio.com/downloads/#visual-studio-enterprise-2017) or later        
-> - [Team Foundation Server Office® Integration 2017](https://www.visualstudio.com/downloads/#team-foundation-server-office-integration-2017) or later
+> **This extension requires Microsoft Excel and the Azure DevOps Office Integration add-on. There are two options for obtaining the add-on:**
+> - [Azure DevOps Office® Integration](https://visualstudio.microsoft.com/downloads/#azure-devops-office-integration-2019)
+> - [Full Visual Studio Installer](https://www.visualstudio.com/downloads)
 
 Use this extension for bulk editing work items, or to leverage Excel tools to analyze and visualize a large number of work items. Work items that are opened in Excel can be edited and published back to Azure DevOps with a single click. Once you are ready to publish your changes, simply hit "Publish" from Excel to sync your changes back to Azure DevOps. [Learn more about Office integration](https://www.visualstudio.com/da-dk/docs/work/office/bulk-add-modify-work-items-excel)
 

--- a/dialog.html
+++ b/dialog.html
@@ -23,11 +23,11 @@
     </script>
 
     <div id="content">
-        <div>Thanks for using <a href="javascript:openUrl('https://aka.ms/open-in-excel')">Azure DevOps Open in Excel</a>.</div>
-        <div>This extension requires Microsoft Excel and one of the following clients to be installed:</div>
+        <div>Thanks for using <a href="javascript:openUrl('https://aka.ms/open-in-excel')">Azure DevOps Open in Excel</a>.</div><br>
+        <div>This extension requires Microsoft Excel and the Azure DevOps Office Integration add-on. There are two options for obtaining the add-on:</div>
         <ul>
-            <li><span>Visual Studio 2017 RTW (or later): <a href="javascript:openUrl('https://www.visualstudio.com/downloads')">Download</a></span></li>
-            <li><span>Team Foundation Server Office® Integration 2017 RTW (or later): <a href="javascript:openUrl('https://www.visualstudio.com/downloads/#team-foundation-server-office-integration-2017')">Download</a></span></li>
+            <li><span>Azure DevOps Office Integration: <a href="javascript:openUrl('https://visualstudio.microsoft.com/downloads/#azure-devops-office-integration-2019')">Download</a></span></li>
+            <li><span>Full Visual Studio Installer: <a href="javascript:openUrl('https://www.visualstudio.com/downloads')">Download</a></span></li>
         </ul>
         <div id="message">This dialog will close in <span id="countdown"></span> seconds... <a href="javascript:cancelAutoClose()">cancel</a></div>
     </div>

--- a/readme.md
+++ b/readme.md
@@ -1,8 +1,8 @@
 # Open in Excel
 
-> **This extension requires Microsoft Excel and one of the following clients to be installed:**
-> - [Visual Studio 2017](https://www.visualstudio.com/downloads/#visual-studio-enterprise-2017) or later        
-> - [Team Foundation Server Office® Integration 2017](https://www.visualstudio.com/downloads/#team-foundation-server-office-integration-2017) or later
+> **This extension requires Microsoft Excel and the Azure DevOps Office Integration add-on. There are two options for obtaining the add-on:**
+> - [Azure DevOps Office Integration](https://visualstudio.microsoft.com/downloads/#azure-devops-office-integration-2019)
+> - [Full Visual Studio Installer](https://www.visualstudio.com/downloads)
 
 An extension for Azure DevOps that enables opening query results in Excel from the web. 
 

--- a/vss-extension.json
+++ b/vss-extension.json
@@ -1,7 +1,7 @@
 {
   "manifestVersion": 1,
   "id": "vsts-open-work-items-in-excel",
-  "version": "0.1.71",
+  "version": "0.1.72",
   "name": "Azure DevOps Open in Excel",
   "scopes": [
     "vso.work",


### PR DESCRIPTION
We've had a lot of confusion from our users on where & how to download the Excel plug-in for DevOps and the links didn't seem to go exactly where they once did. We're now using this version of the plug-in and would be happy to see the official version updated with this text.